### PR TITLE
Some stuff that came up as usability concerns

### DIFF
--- a/src/main/java/functional/algebraic/Either.java
+++ b/src/main/java/functional/algebraic/Either.java
@@ -35,6 +35,7 @@ import java.util.function.Function;
  * @param <L> The left alternative type
  * @param <R> The right alternative type
  * @author Zoey Hewll
+ * @author Eleanor McMurtry
  */
 public abstract class Either<L, R>
 {

--- a/src/main/java/functional/algebraic/Either.java
+++ b/src/main/java/functional/algebraic/Either.java
@@ -83,7 +83,7 @@ public abstract class Either<L, R>
      * @param <T> The return type of the functions.
      * @return The value returned by the matched function.
      */
-    public <T> T match(Function<? super L, ? extends T> lf, Function<? super R, ? extends T> rf)
+    public <T> T matchThen(Function<? super L, ? extends T> lf, Function<? super R, ? extends T> rf)
     {
         return unsafeMatch(
                 lf::apply,
@@ -119,7 +119,7 @@ public abstract class Either<L, R>
      */
     public <A, B> Either<A, B> bimap(Function<? super L, ? extends A> lf, Function<? super R, ? extends B> rf)
     {
-        return match(
+        return matchThen(
                 (L l) -> left(lf.apply(l)),
                 (R r) -> right(rf.apply(r))
         );
@@ -133,7 +133,7 @@ public abstract class Either<L, R>
      */
     public L fromLeft(L left)
     {
-        return match(
+        return matchThen(
                 (L l) -> l,
                 (R r) -> left
         );
@@ -147,7 +147,7 @@ public abstract class Either<L, R>
      */
     public R fromRight(R right)
     {
-        return match(
+        return matchThen(
                 (L l) -> right,
                 (R r) -> r
         );
@@ -186,7 +186,7 @@ public abstract class Either<L, R>
      */
     public boolean isLeft()
     {
-        return match(
+        return matchThen(
                 (L l) -> true,
                 (R r) -> false
         );
@@ -199,7 +199,7 @@ public abstract class Either<L, R>
      */
     public boolean isRight()
     {
-        return match(
+        return matchThen(
                 (L l) -> false,
                 (R r) -> true
         );
@@ -241,7 +241,7 @@ public abstract class Either<L, R>
      */
     static <L, R> Either<L, R> cast(Either<? extends L, ? extends R> either)
     {
-        return either.match(
+        return either.matchThen(
                 (L l) -> left(l),
                 (R r) -> right(r)
         );

--- a/src/main/java/functional/algebraic/Either.java
+++ b/src/main/java/functional/algebraic/Either.java
@@ -103,6 +103,17 @@ public abstract class Either<L, R>
                 rf::accept);
     }
 
+
+    /**
+     * Applies a function that can take any Object to whichever value is contained.
+     *
+     * @param f the function to apply
+     */
+    public void collapse(Consumer<Object> f) {
+        match(f, f);
+    }
+
+
     /**
      * <p>Apply a function to the contained value, and return an {@link Either} corresponding to the return types.
      * The functions need not return the same type.

--- a/src/main/java/functional/algebraic/Maybe.java
+++ b/src/main/java/functional/algebraic/Maybe.java
@@ -22,6 +22,7 @@ import functional.throwing.ThrowingConsumer;
 import functional.throwing.ThrowingFunction;
 import functional.throwing.ThrowingRunnable;
 import functional.throwing.ThrowingSupplier;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -220,7 +221,7 @@ public abstract class Maybe<V> implements ThrowingSupplier<V, IllegalStateExcept
      * @return nothing() if the value is null, and just(value) otherwise
      * @param <V> The type of the optional value
      */
-    public static <V> Maybe<V> of(V value)
+    public static <V> Maybe<V> of(@Nullable V value)
     {
         return value == null
                 ? nothing()

--- a/src/main/java/functional/algebraic/Maybe.java
+++ b/src/main/java/functional/algebraic/Maybe.java
@@ -62,7 +62,7 @@ import java.util.function.Supplier;
  *
  * @param <V> The type of the optional value
  * @author Zoey Hewll
- * @author Eleanor McMurtry (renamed match overloads to avoid inference errors)
+ * @author Eleanor McMurtry
  */
 public abstract class Maybe<V> implements ThrowingSupplier<V, IllegalStateException>
 {

--- a/src/main/java/functional/algebraic/Maybe.java
+++ b/src/main/java/functional/algebraic/Maybe.java
@@ -22,7 +22,6 @@ import functional.throwing.ThrowingConsumer;
 import functional.throwing.ThrowingFunction;
 import functional.throwing.ThrowingRunnable;
 import functional.throwing.ThrowingSupplier;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -206,6 +205,10 @@ public abstract class Maybe<V> implements ThrowingSupplier<V, IllegalStateExcept
         );
     }
 
+    /**
+     * Consumes the value inside this Result, if there is one.
+     * @param consumer the consuming operation
+     */
     public void consume(Consumer<V> consumer) {
         match(consumer, Combinators::noop);
     }
@@ -217,7 +220,7 @@ public abstract class Maybe<V> implements ThrowingSupplier<V, IllegalStateExcept
      * @return nothing() if the value is null, and just(value) otherwise
      * @param <V> The type of the optional value
      */
-    public static <V> Maybe<V> of(@Nullable V value)
+    public static <V> Maybe<V> of(V value)
     {
         return value == null
                 ? nothing()

--- a/src/main/java/functional/algebraic/Maybe.java
+++ b/src/main/java/functional/algebraic/Maybe.java
@@ -206,7 +206,7 @@ public abstract class Maybe<V> implements ThrowingSupplier<V, IllegalStateExcept
     }
 
     /**
-     * Consumes the value inside this Result, if there is one.
+     * Consumes the value inside this Maybe, if there is one.
      * @param consumer the consuming operation
      */
     public void consume(Consumer<V> consumer) {

--- a/src/main/java/functional/algebraic/Result.java
+++ b/src/main/java/functional/algebraic/Result.java
@@ -40,6 +40,7 @@ import java.util.function.Supplier;
  * @param <E> the error alternative type.
  * @param <V> the value alternative type.
  * @author Zoey Hewll
+ * @author Eleanor McMurtry
  */
 public class Result<E extends Exception, V> implements ThrowingSupplier<V, E>
 {

--- a/src/main/java/functional/algebraic/Result.java
+++ b/src/main/java/functional/algebraic/Result.java
@@ -424,7 +424,7 @@ public class Result<E extends Exception, V> implements ThrowingSupplier<V, E>
      * @param op the operation
      * @return the unaltered Result
      */
-    public Result<E, V> err(Consumer<? super E> op) {
+    public Result<E, V> ifErr(Consumer<? super E> op) {
         match(op, Combinators::noop);
         return this;
     }

--- a/src/main/java/functional/algebraic/Result.java
+++ b/src/main/java/functional/algebraic/Result.java
@@ -414,7 +414,7 @@ public class Result<E extends Exception, V> implements ThrowingSupplier<V, E>
      * @param op the operation
      * @return the unaltered Result
      */
-    public Result<E, V> ok(Consumer<? super V> op) {
+    public Result<E, V> ifOk(Consumer<? super V> op) {
         match(Combinators::noop, op);
         return this;
     }

--- a/src/main/java/functional/algebraic/Result.java
+++ b/src/main/java/functional/algebraic/Result.java
@@ -526,7 +526,7 @@ public class Result<E extends Exception, V> implements ThrowingSupplier<V, E>
      * @param f the function
      * @return
      */
-    public V consumeError(Function<? super E, ? extends V> f) {
+    public V convertError(Function<? super E, ? extends V> f) {
         return matchThen(f, Combinators::id);
     }
 

--- a/src/main/java/functional/algebraic/Result.java
+++ b/src/main/java/functional/algebraic/Result.java
@@ -290,7 +290,7 @@ public class Result<E extends Exception, V> implements ThrowingSupplier<V, E>
      * @param f the function to apply
      */
     public void collapse(Consumer<Object> f) {
-        either.match(f, f);
+        either.collapse(f);
     }
 
     /**

--- a/src/main/java/functional/algebraic/Result.java
+++ b/src/main/java/functional/algebraic/Result.java
@@ -507,7 +507,13 @@ public class Result<E extends Exception, V> implements ThrowingSupplier<V, E>
         );
     }
 
-    public <T extends Exception> Result<T, V> mapError(Function<? super E, ? extends T> f) {
+    /**
+     * Maps a function of errors to the error inside this Result, or does nothing if there is none.
+     * @param f the function to apply
+     * @param <F> the resulting error type
+     * @return the mapped Result
+     */
+    public <F extends Exception> Result<F, V> mapError(Function<? super E, ? extends F> f) {
         return matchThen(
                 (E e) -> error(f.apply(e)),
                 (V v) -> value(v)

--- a/src/main/java/functional/algebraic/Result.java
+++ b/src/main/java/functional/algebraic/Result.java
@@ -300,7 +300,10 @@ public class Result<E extends Exception, V> implements ThrowingSupplier<V, E>
      * @return the value or default
      */
     public V orElse(V defaultValue) {
-        return either.matchThen(ignored -> defaultValue, val -> val);
+        return either.matchThen(
+            __ -> defaultValue,
+            val -> val
+        );
     }
 
     /**

--- a/src/main/java/functional/combinator/Combinators.java
+++ b/src/main/java/functional/combinator/Combinators.java
@@ -34,6 +34,7 @@ public final class Combinators
     }
 
     public static <A> void noop(A __) {}
+    public static <A> void noop() {}
 
     public static <A, B, C> Function<A, C> compose(Function<A, B> ab, Function<B, C> bc)
     {

--- a/src/test/java/functional/algebraic/EitherTest.java
+++ b/src/test/java/functional/algebraic/EitherTest.java
@@ -153,7 +153,7 @@ public class EitherTest
     @Test
     public void matchTestProducingLeft()
     {
-        assertTrue(left(0).match(
+        assertTrue(left(0).matchThen(
                 l -> l == 0,
                 r -> false)
         );
@@ -162,7 +162,7 @@ public class EitherTest
     @Test
     public void matchTestProducingRight()
     {
-        assertTrue(right(0).match(
+        assertTrue(right(0).matchThen(
                 l -> false,
                 r -> r == 0)
         );

--- a/src/test/java/functional/algebraic/MaybeTest.java
+++ b/src/test/java/functional/algebraic/MaybeTest.java
@@ -68,8 +68,8 @@ public class MaybeTest
     @Test
     public void fromMaybeTest()
     {
-        assertTrue(Maybe.<Boolean>just(true).fromMaybe(false));
-        assertFalse(Maybe.<Boolean>nothing().fromMaybe(false));
+        assertTrue(Maybe.<Boolean>just(true).orElse(false));
+        assertFalse(Maybe.<Boolean>nothing().orElse(false));
     }
 
     @Test


### PR DESCRIPTION
Consolidated terminology (`Maybe` wasn't up to date with `bind` --> `andThen`). Added `ok` and `err` to `Result` (a la Rust). Added `orElse` to `Result`. Replaced `match` overloads with `matchThen`, so that the type inferencing doesn't get confused.

I didn't add any new test cases, sorry!